### PR TITLE
feat: get all recycling logs

### DIFF
--- a/src/controllers/recycling.controller.ts
+++ b/src/controllers/recycling.controller.ts
@@ -22,3 +22,15 @@ export const createRecyclingLog = asyncHandler(
     );
   },
 );
+
+export const getAllRecyclingLog = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const response = await recyclingService.fetchAllRecyclingLog();
+
+    responseHandler.sendSuccessResponse(
+      res,
+      "Retrieved successfully",
+      response,
+    );
+  },
+);

--- a/src/docs/recycling.doc.ts
+++ b/src/docs/recycling.doc.ts
@@ -1,0 +1,126 @@
+/**
+ * @swagger
+ * /api/v1/recycling:
+ *   post:
+ *     summary: Create a recycling log
+ *     description: This endpoint allows authenticated users to create a recycling log by providing the materials and their respective quantities.
+ *     tags:
+ *       - Recycling
+ *     security:
+ *       - bearerAuth: []  # Assumes you're using Bearer token authentication
+ *     requestBody:
+ *       description: The materials and quantities being recycled by the user
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               materials:
+ *                 type: array
+ *                 description: An array of materials with their types and quantities
+ *                 items:
+ *                   type: object
+ *                   properties:
+ *                     materialType:
+ *                       type: string
+ *                       enum: [plastic, tin, bottle, others]
+ *                       description: The type of recycling material
+ *                       example: plastic
+ *                     quantity:
+ *                       type: number
+ *                       description: The quantity of the recycling material
+ *                       example: 10
+ *             example:
+ *               materials:
+ *                 - materialType: plastic
+ *                   quantity: 10
+ *                 - materialType: bottle
+ *                   quantity: 2
+ *     responses:
+ *       201:
+ *         description: Recycling log created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: "created"
+ *                 message:
+ *                   type: string
+ *                   example: "Recycling log created successfully"
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     recycling:
+ *                       type: array
+ *                       description: The recycling records created for the user
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           user:
+ *                             type: string
+ *                             format: uuid
+ *                             description: The user ID associated with the recycling record
+ *                             example: "ebf04518-0ff9-4b40-93a8-3fa8f1ba02cb"
+ *                           material:
+ *                             type: string
+ *                             description: The type of recycling material
+ *                             example: "plastic"
+ *                           point:
+ *                             type: number
+ *                             description: Points assigned for the recycling action
+ *                             example: 4
+ *                           quantity:
+ *                             type: number
+ *                             description: The quantity of the recycled material
+ *                             example: 10
+ *                           id:
+ *                             type: string
+ *                             format: uuid
+ *                             description: The unique ID of the recycling log
+ *                             example: "28cef7fc-f6ba-4293-b1b5-e9bbdb9ac703"
+ *                           created_at:
+ *                             type: string
+ *                             format: date-time
+ *                             description: When the recycling log was created
+ *                             example: "2024-09-14T04:05:27.618Z"
+ *                           updated_at:
+ *                             type: string
+ *                             format: date-time
+ *                             description: When the recycling log was last updated
+ *                             example: "2024-09-14T04:05:27.618Z"
+ *                           deleted_at:
+ *                             type: string
+ *                             format: date-time
+ *                             description: When the recycling log was deleted (if applicable)
+ *                             example: null
+ *       400:
+ *         description: Bad request. Invalid input or missing fields.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: "error"
+ *                 message:
+ *                   type: string
+ *                   example: "Invalid input data"
+ *       401:
+ *         description: Unauthorized. The user is not authenticated.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: "error"
+ *                 message:
+ *                   type: string
+ *                   example: "Unauthorized"
+ */

--- a/src/docs/recycling.doc.ts
+++ b/src/docs/recycling.doc.ts
@@ -1,3 +1,4 @@
+export const createRecyclingDocs = `
 /**
  * @swagger
  * /api/v1/recycling:
@@ -124,3 +125,109 @@
  *                   type: string
  *                   example: "Unauthorized"
  */
+`;
+
+export const getAllRecyclingLog = `
+/**
+ * @swagger
+ * /api/v1/recycling:
+ *   get:
+ *     summary: Get all recycling logs
+ *     description: This endpoint retrieves all recycling logs. Optionally, logs can be filtered by user or other criteria.
+ *     tags:
+ *       - Recycling
+ *     security:
+ *       - bearerAuth: []  # Assumes you're using Bearer token authentication
+ *     parameters:
+ *       - in: query
+ *         name: userId
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         required: false
+ *         description: Optional user ID to filter recycling logs by a specific user
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved recycling logs
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: "success"
+ *                 message:
+ *                   type: string
+ *                   example: "Recycling logs retrieved successfully"
+ *                 data:
+ *                   type: array
+ *                   description: Array of recycling log records
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       user:
+ *                         type: string
+ *                         format: uuid
+ *                         description: The user ID associated with the recycling record
+ *                         example: "ebf04518-0ff9-4b40-93a8-3fa8f1ba02cb"
+ *                       material:
+ *                         type: string
+ *                         description: The type of recycling material
+ *                         example: "plastic"
+ *                       point:
+ *                         type: number
+ *                         description: Points assigned for the recycling action
+ *                         example: 4
+ *                       quantity:
+ *                         type: number
+ *                         description: The quantity of the recycled material
+ *                         example: 10
+ *                       id:
+ *                         type: string
+ *                         format: uuid
+ *                         description: The unique ID of the recycling log
+ *                         example: "28cef7fc-f6ba-4293-b1b5-e9bbdb9ac703"
+ *                       created_at:
+ *                         type: string
+ *                         format: date-time
+ *                         description: When the recycling log was created
+ *                         example: "2024-09-14T04:05:27.618Z"
+ *                       updated_at:
+ *                         type: string
+ *                         format: date-time
+ *                         description: When the recycling log was last updated
+ *                         example: "2024-09-14T04:05:27.618Z"
+ *                       deleted_at:
+ *                         type: string
+ *                         format: date-time
+ *                         description: When the recycling log was deleted (if applicable)
+ *                         example: null
+ *       400:
+ *         description: Bad request. Invalid input or missing fields.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: "error"
+ *                 message:
+ *                   type: string
+ *                   example: "Invalid query parameters"
+ *       401:
+ *         description: Unauthorized. The user is not authenticated.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: "error"
+ *                 message:
+ *                   type: string
+ *                   example: "Unauthorized"
+ */
+`;

--- a/src/dtos/recycling.dto.ts
+++ b/src/dtos/recycling.dto.ts
@@ -1,0 +1,12 @@
+import { Recycling } from "../entities/recycling.entity";
+
+export const recyclingDTO = (data: Recycling[]) => {
+  const recyclingDTO = data.map((item) => {
+    return {
+      ...item,
+      user: item.user.id,
+    };
+  });
+
+  return recyclingDTO;
+};

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,3 +1,4 @@
+import { RECYCLINGMATERIALENUM } from "../entities/recycling-material.entity";
 import { IUpdateUserProfileSchema } from "../schemas/user";
 
 import { JwtPayload } from "jsonwebtoken";
@@ -46,4 +47,15 @@ export type UserUpdatePayload = IUpdateUserProfileSchema & {
 
 export interface IUserProfilePicturePayload {
   photo: string;
+}
+
+export interface IRecyclingDTO {
+  user: string;
+  material: RECYCLINGMATERIALENUM;
+  quantity: number;
+  point: number;
+  id: string;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date;
 }

--- a/src/routes/recycling.route.ts
+++ b/src/routes/recycling.route.ts
@@ -1,5 +1,8 @@
 import { Router } from "express";
-import { createRecyclingLog } from "../controllers/recycling.controller";
+import {
+  createRecyclingLog,
+  getAllRecyclingLog,
+} from "../controllers/recycling.controller";
 import { deserializeUser } from "../middlewares/deserializeUser";
 import { validateData } from "../middlewares/validateData";
 import { recyclingSchema } from "../schemas/recycling";
@@ -12,5 +15,7 @@ recyclingRouter.post(
   deserializeUser,
   createRecyclingLog,
 );
+
+recyclingRouter.get("/", getAllRecyclingLog);
 
 export default recyclingRouter;

--- a/src/services/recycling.service.ts
+++ b/src/services/recycling.service.ts
@@ -1,4 +1,6 @@
+import { recyclingDTO } from "../dtos/recycling.dto";
 import { Recycling } from "../entities/recycling.entity";
+import { IRecyclingDTO } from "../interfaces";
 import { IRecyclingSchema } from "../schemas/recycling";
 import rewardPointSystem from "../utils/reward-point-syetem";
 import { UserService } from "./user.service";
@@ -10,7 +12,7 @@ export class RecyclingService {
     userId: string,
   ): Promise<{
     message: string;
-    record: { recycling?: any };
+    record: { recycling?: IRecyclingDTO[] };
   }> {
     const user = await userService.fetchUserRecord(userId, "userId");
 
@@ -24,17 +26,18 @@ export class RecyclingService {
     });
 
     const recycling = await Recycling.save(recyclingEntities);
-    const recyclingDTO = recycling.map((item) => {
-      return {
-        ...item,
-        user: item.user.id,
-      };
-    });
+    const DTOResponse = recyclingDTO(recycling);
     return {
       message: "Recycling log created successfully",
       record: {
-        recycling: recyclingDTO,
+        recycling: DTOResponse,
       },
     };
+  }
+
+  public async fetchAllRecyclingLog(): Promise<IRecyclingDTO[] | null> {
+    const recycling = await Recycling.find({ relations: ["user"] });
+    const DTOResponse = recyclingDTO(recycling);
+    return DTOResponse;
   }
 }


### PR DESCRIPTION
### Description
This commit includes the api feature to update the user profile picture and also to update the user profile. 
> This pr closes issues- #12  

Changes include:
- [x] Added API endpoint to create recycling log (`GET /api/v1/recycling`)
- [x] API documentation 
- [ ] Tests added for both endpoints

### Payload Examples:
1. Get Recycling log:
```bash
GET /api/v1/recycling
{
    "status": "successs",
    "message": "Retrieved successfully",
    "data": [
        {
            "id": "28cef7fc-f6ba-4293-b1b5-e9bbdb9ac703",
            "created_at": "2024-09-14T04:05:27.618Z",
            "updated_at": "2024-09-14T04:05:27.618Z",
            "deleted_at": null,
            "material": "plastic",
            "quantity": 10,
            "point": 4,
            "user": "ebf04518-0ff9-4b40-93a8-3fa8f1ba02cb"
        },
        {
            "id": "247fdd67-58ea-4f29-9c10-93105c0004c3",
            "created_at": "2024-09-14T04:05:27.618Z",
            "updated_at": "2024-09-14T04:05:27.618Z",
            "deleted_at": null,
            "material": "bottle",
            "quantity": 2,
            "point": 1,
            "user": "ebf04518-0ff9-4b40-93a8-3fa8f1ba02cb"
        }
    ]
}
```
