### PR TITLE
feat: get single recycle log 

### DIFF
--- a/src/controllers/recycling.controller.ts
+++ b/src/controllers/recycling.controller.ts
@@ -34,3 +34,17 @@ export const getAllRecyclingLog = asyncHandler(
     );
   },
 );
+
+export const getRecyclingLogById = asyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const response = await recyclingService.fetchRecyclingLogById(
+      req.params.recycle_id,
+    );
+
+    responseHandler.sendSuccessResponse(
+      res,
+      "Retrieved successfully",
+      response,
+    );
+  },
+);

--- a/src/docs/recycling.doc.ts
+++ b/src/docs/recycling.doc.ts
@@ -7,8 +7,6 @@ export const createRecyclingDocs = `
  *     description: This endpoint allows authenticated users to create a recycling log by providing the materials and their respective quantities.
  *     tags:
  *       - Recycling
- *     security:
- *       - bearerAuth: []  # Assumes you're using Bearer token authentication
  *     requestBody:
  *       description: The materials and quantities being recycled by the user
  *       required: true
@@ -111,19 +109,6 @@ export const createRecyclingDocs = `
  *                 message:
  *                   type: string
  *                   example: "Invalid input data"
- *       401:
- *         description: Unauthorized. The user is not authenticated.
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 status:
- *                   type: string
- *                   example: "error"
- *                 message:
- *                   type: string
- *                   example: "Unauthorized"
  */
 `;
 
@@ -229,5 +214,118 @@ export const getAllRecyclingLog = `
  *                 message:
  *                   type: string
  *                   example: "Unauthorized"
+ */
+`;
+
+export const getSingleRecyclingLog = `
+/**
+ * @swagger
+ * /api/v1/recycling/{recycle_id}:
+ *   get:
+ *     summary: Get a single recycling log
+ *     description: This endpoint retrieves a single recycling log by its ID.
+ *     tags:
+ *       - Recycling
+ *     parameters:
+ *       - in: path
+ *         name: recycle_id
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         required: true
+ *         description: The ID of the recycling log to retrieve
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved the recycling log
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: "success"
+ *                 message:
+ *                   type: string
+ *                   example: "Recycling log retrieved successfully"
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     user:
+ *                       type: string
+ *                       format: uuid
+ *                       description: The user ID associated with the recycling record
+ *                       example: "ebf04518-0ff9-4b40-93a8-3fa8f1ba02cb"
+ *                     material:
+ *                       type: string
+ *                       description: The type of recycling material
+ *                       example: "plastic"
+ *                     point:
+ *                       type: number
+ *                       description: Points assigned for the recycling action
+ *                       example: 4
+ *                     quantity:
+ *                       type: number
+ *                       description: The quantity of the recycled material
+ *                       example: 10
+ *                     id:
+ *                       type: string
+ *                       format: uuid
+ *                       description: The unique ID of the recycling log
+ *                       example: "28cef7fc-f6ba-4293-b1b5-e9bbdb9ac703"
+ *                     created_at:
+ *                       type: string
+ *                       format: date-time
+ *                       description: When the recycling log was created
+ *                       example: "2024-09-14T04:05:27.618Z"
+ *                     updated_at:
+ *                       type: string
+ *                       format: date-time
+ *                       description: When the recycling log was last updated
+ *                       example: "2024-09-14T04:05:27.618Z"
+ *                     deleted_at:
+ *                       type: string
+ *                       format: date-time
+ *                       description: When the recycling log was deleted (if applicable)
+ *                       example: null
+ *       400:
+ *         description: Bad request. Invalid input or missing fields.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: "error"
+ *                 message:
+ *                   type: string
+ *                   example: "Invalid recycling log ID"
+ *       401:
+ *         description: Unauthorized. The user is not authenticated.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: "error"
+ *                 message:
+ *                   type: string
+ *                   example: "Unauthorized"
+ *       404:
+ *         description: Not found. The specified recycling log does not exist.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: "error"
+ *                 message:
+ *                   type: string
+ *                   example: "Recycling log not found"
  */
 `;

--- a/src/dtos/recycling.dto.ts
+++ b/src/dtos/recycling.dto.ts
@@ -1,12 +1,17 @@
 import { Recycling } from "../entities/recycling.entity";
+import { ClientError } from "../exceptions/clientError";
 
 export const recyclingDTO = (data: Recycling[]) => {
-  const recyclingDTO = data.map((item) => {
-    return {
-      ...item,
-      user: item.user.id,
-    };
-  });
+  try {
+    const recyclingDTO = data.map((item) => {
+      return {
+        ...item,
+        user: item.user.id,
+      };
+    });
 
-  return recyclingDTO;
+    return recyclingDTO;
+  } catch (error) {
+    throw new ClientError("Error converting recycling DTO");
+  }
 };

--- a/src/routes/recycling.route.ts
+++ b/src/routes/recycling.route.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import {
   createRecyclingLog,
   getAllRecyclingLog,
+  getRecyclingLogById,
 } from "../controllers/recycling.controller";
 import { deserializeUser } from "../middlewares/deserializeUser";
 import { validateData } from "../middlewares/validateData";
@@ -17,5 +18,9 @@ recyclingRouter.post(
 );
 
 recyclingRouter.get("/", getAllRecyclingLog);
+
+recyclingRouter.get("/", getAllRecyclingLog);
+
+recyclingRouter.get("/:recycle_id", getRecyclingLogById);
 
 export default recyclingRouter;

--- a/src/services/recycling.service.ts
+++ b/src/services/recycling.service.ts
@@ -40,4 +40,15 @@ export class RecyclingService {
     const DTOResponse = recyclingDTO(recycling);
     return DTOResponse;
   }
+
+  public async fetchRecyclingLogById(
+    recycleId: string,
+  ): Promise<IRecyclingDTO | null> {
+    const recycling = await Recycling.findOne({
+      where: { id: recycleId },
+      relations: ["user"],
+    });
+    const DTOResponse = recyclingDTO([recycling])[0];
+    return DTOResponse;
+  }
 }


### PR DESCRIPTION
### Description
This commit includes the api feature to update the user profile picture and also to update the user profile. 
This pr closes issues- {}

Changes include:
- [x] Added API endpoint to create recycling log (`GET /api/v1/recycling/:recycle_id`)
- [x] API documentation 
- [ ] Tests added for both endpoints

### Payload Examples:
1. Get Recycling log by ID:
```bash
GET /api/v1/recycling/:recycle_id
{
    "status": "successs",
    "message": "Retrieved successfully",
    "data": {
            "id": "247fdd67-58ea-4f29-9c10-93105c0004c3",
            "created_at": "2024-09-14T04:05:27.618Z",
            "updated_at": "2024-09-14T04:05:27.618Z",
            "deleted_at": null,
            "material": "bottle",
            "quantity": 2,
            "point": 1,
            "user": "ebf04518-0ff9-4b40-93a8-3fa8f1ba02cb"
        }
}
```
